### PR TITLE
chore: update database connection to Railway

### DIFF
--- a/src/main/java/hibernate.cfg.xml
+++ b/src/main/java/hibernate.cfg.xml
@@ -5,8 +5,9 @@
 <hibernate-configuration>
     <session-factory>
         <property name="hibernate.connection.driver_class">com.mysql.jdbc.Driver</property>
-        <property name="hibernate.connection.url">jdbc:mysql://localhost:3306/mookata_thestar</property>
+        <property name="hibernate.connection.url">jdbc:mysql://caboose.proxy.rlwy.net:46250/railway</property>
         <property name="hibernate.connection.username">root</property>
+        <property name="hibernate.connection.password">ZuEyymBtaMqSuTegxZgqZAngncXDjxQt</property>
         <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>
     </session-factory>
 </hibernate-configuration>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/mookata_thestar?characterEncoding=utf-8
+spring.datasource.url=jdbc:mysql://caboose.proxy.rlwy.net:46250/railway?characterEncoding=utf-8
 spring.datasource.driver-class-name=com.mysql.jdbc.Driver
 spring.datasource.username=root
-spring.datasource.password=
+spring.datasource.password=ZuEyymBtaMqSuTegxZgqZAngncXDjxQt
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 


### PR DESCRIPTION
 ## Description
This PR updates the application's database configuration to connect to the remote MySQL database hosted on Railway. It also ensures that all necessary settings are consistent across both Spring Boot and native Hibernate configurations.

## Changes
- **`src/main/resources/application.properties`**: Updated `spring.datasource` URL, username, and password.
- **`src/main/java/hibernate.cfg.xml`**: Updated Hibernate connection properties to match the remote database.
- **Database Migration**: Imported `mookata_thestar.sql` from the local environment into the Railway `railway` database.

## Verification Results
- [x] Verified TCP connectivity to `caboose.proxy.rlwy.net:46250`.
- [x] Confirmed database tables (`product`, `promotion`, `categories`, etc.) are present in the remote instance.
- [x] Application successfully initializes with the new credentials.

## Note
The previous local database `mookata_thestar` is no longer required for development as the application now points to the centralized Railway instance.